### PR TITLE
Prioritize converter section and improve upload flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,12 @@ const SUPPORTED_TYPES = [
   'video/quicktime',
 ];
 const MAX_DURATION_SECONDS = 120;
+const EXTENSION_BY_MIME = {
+  'video/mp4': '.mp4',
+  'video/webm': '.webm',
+  'video/ogg': '.ogg',
+  'video/quicktime': '.mov',
+};
 
 const dropZone = document.getElementById('dropZone');
 const videoInput = document.getElementById('videoInput');
@@ -112,6 +118,17 @@ function getVideoDuration(file) {
   });
 }
 
+function resolveInputName(file) {
+  const mimeExtension = EXTENSION_BY_MIME[file.type];
+  if (mimeExtension) {
+    return `input-${Date.now()}${mimeExtension}`;
+  }
+
+  const nameMatch = file.name && file.name.match(/(\.[a-zA-Z0-9]{2,5})$/);
+  const fallbackExtension = nameMatch ? nameMatch[1].toLowerCase() : '.mp4';
+  return `input-${Date.now()}${fallbackExtension}`;
+}
+
 async function handleFileSelection(file) {
   if (!file) return;
 
@@ -130,7 +147,7 @@ async function handleFileSelection(file) {
     durationCache = duration;
     const sizeMb = (file.size / 1024 / 1024).toFixed(1);
     setStatus(
-      `Archivo listo · ${formatDuration(duration)} · ${sizeMb} MB`,
+      `Listo: ${file.name} · ${formatDuration(duration)} · ${sizeMb} MB`,
       'success',
     );
     convertButton.disabled = false;
@@ -156,7 +173,7 @@ async function convertToGif() {
   try {
     await ensureFFmpegLoaded();
 
-    inputName = `input${Date.now()}`;
+    inputName = resolveInputName(selectedFile);
 
     ffmpeg.FS('writeFile', inputName, await fetchFile(selectedFile));
 
@@ -256,6 +273,7 @@ videoInput.addEventListener('change', (event) => {
   if (file) {
     handleFileSelection(file);
   }
+  event.target.value = '';
 });
 
 convertButton.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -25,68 +25,23 @@
           <span class="brand-name">NeonGIF Studio</span>
         </a>
         <div class="nav-actions">
-          <a class="link" href="#caracteristicas">Características</a>
+          <a class="link" href="#convertidor">Crear GIF</a>
+          <a class="link" href="#apoyo">Apoyar proyecto</a>
           <a class="link" href="#flujo">Cómo funciona</a>
-          <a class="cta" href="#convertidor">Probar ahora</a>
+          <a class="cta" href="#convertidor">Comenzar</a>
         </div>
       </nav>
     </header>
 
     <main id="inicio" class="page">
-      <section class="hero">
-        <div class="hero-content">
-          <p class="eyebrow">Convierte. Optimiza. Comparte.</p>
-          <h1>
-            Dale <span class="highlight">ritmo neon</span> a tus clips y
-            obtén GIFs listos para viralizar.
-          </h1>
-          <p class="hero-description">
-            Sube un video corto, presiona convertir y obtén un GIF liviano sin
-            salir de tu navegador. Todo el procesamiento ocurre en tu equipo,
-            sin colas, sin esperas.
-          </p>
-          <div class="hero-stats">
-            <div class="stat-card">
-              <span class="stat-value">120s</span>
-              <span class="stat-label">Duración máxima por clip</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-value">15 FPS</span>
-              <span class="stat-label">Fluidez optimizada para compartir</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-value">100% local</span>
-              <span class="stat-label">Tus archivos no salen del navegador</span>
-            </div>
-          </div>
-          <div class="hero-cta">
-            <a class="cta large" href="#convertidor">Comenzar conversión</a>
-            <p class="disclaimer">Formatos aceptados: MP4, WEBM, OGG, MOV.</p>
-          </div>
-        </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="orb"></div>
-          <div class="card floating">
-            <span class="card-title">Preset Neon</span>
-            <span class="card-value">GIF optimizado · 480px</span>
-            <div class="signal">
-              <span></span><span></span><span></span>
-            </div>
-          </div>
-          <div class="card floating delay">
-            <span class="card-title">Conversión segura</span>
-            <span class="card-value">Procesamiento local</span>
-          </div>
-        </div>
-      </section>
-
       <section id="convertidor" class="converter">
         <div class="panel">
-          <h2>Convierte tu video en un GIF hipnótico</h2>
+          <p class="eyebrow">Convierte. Optimiza. Comparte.</p>
+          <h1>Convierte tu video en un GIF hipnótico</h1>
           <p class="panel-description">
             Arrastra tu archivo al área o selecciónalo desde tu dispositivo.
             El botón se activará automáticamente cuando validemos el formato y la
-            duración.
+            duración para que empieces la magia de inmediato.
           </p>
 
           <div class="drop-zone" id="dropZone" role="button" tabindex="0">
@@ -134,35 +89,32 @@
         </div>
       </section>
 
-      <section id="caracteristicas" class="features">
-        <article class="feature-card">
-          <h3>Flujo guiado</h3>
+      <section id="apoyo" class="support">
+        <div class="support-intro">
+          <h2>Impulsa NeonGIF Studio</h2>
           <p>
-            El panel inteligente revisa duración y formato automáticamente, así
-            evitas intentos fallidos desde el inicio.
+            ¿Te gusta convertir clips en GIFs hipnóticos? Tu aporte nos ayuda a
+            mantener el motor actualizado y a sumar nuevas funciones.
           </p>
-        </article>
-        <article class="feature-card">
-          <h3>Colores vibrantes</h3>
-          <p>
-            Aplicamos filtros y un perfil cromático pensado para resaltar en
-            redes sociales sin perder nitidez.
-          </p>
-        </article>
-        <article class="feature-card">
-          <h3>Privacidad total</h3>
-          <p>
-            La conversión se ejecuta en tu dispositivo usando WebAssembly. Tus
-            clips nunca se suben a un servidor externo.
-          </p>
-        </article>
-        <article class="feature-card">
-          <h3>Optimización automática</h3>
-          <p>
-            Ajustamos fotogramas y escalado para equilibrar peso del archivo con
-            fluidez visual en cualquier plataforma.
-          </p>
-        </article>
+        </div>
+        <div class="support-actions" role="group" aria-label="Opciones de donación">
+          <a
+            class="cta large"
+            href="https://cafecito.app/neongifstudio"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Invítanos un Cafecito
+          </a>
+          <a
+            class="cta ghost large"
+            href="https://commerce.coinbase.com/checkout"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Donar con crypto
+          </a>
+        </div>
       </section>
 
       <section id="flujo" class="workflow">

--- a/styles.css
+++ b/styles.css
@@ -364,9 +364,9 @@ body::after {
   gap: 18px;
 }
 
-.panel h2 {
+.panel h1 {
   font-family: var(--font-display);
-  font-size: clamp(1.8rem, 3vw, 2.3rem);
+  font-size: clamp(2.2rem, 3.5vw, 2.9rem);
   margin: 0;
 }
 
@@ -374,6 +374,45 @@ body::after {
   margin: 0;
   color: var(--color-text-muted);
   line-height: 1.6;
+}
+
+.support {
+  display: grid;
+  gap: 28px;
+  background: linear-gradient(160deg, rgba(19, 27, 42, 0.72), rgba(9, 12, 21, 0.78));
+  padding: 48px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(155, 255, 43, 0.14);
+  box-shadow: var(--shadow-soft);
+}
+
+.support-intro {
+  display: grid;
+  gap: 12px;
+  max-width: 620px;
+}
+
+.support-intro h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
+  margin: 0;
+}
+
+.support-intro p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.support-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.support-actions .cta {
+  flex: 1 1 220px;
+  min-height: 56px;
 }
 
 .drop-zone {
@@ -679,6 +718,10 @@ body::after {
   .nav {
     padding: 16px 24px;
   }
+
+  .support {
+    padding: 40px 28px;
+  }
 }
 
 @media (max-width: 720px) {
@@ -709,5 +752,13 @@ body::after {
 
   .workflow {
     grid-template-columns: 1fr;
+  }
+
+  .support {
+    padding: 32px 20px;
+  }
+
+  .support-actions {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- move the converter panel to the top of the page so users can start dragging their videos right away
- add a new support section with Cafecito and crypto donation buttons ahead of the workflow explanation
- update the upload flow to reuse file extensions for ffmpeg.wasm and clear the input after each selection

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce18531ef88321b02b57eb52357c5e